### PR TITLE
Remove redundant test job from CircleCI configuration to streamline t…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,6 @@
 version: 2.1
 
 jobs:
-  Test_Package:
-    docker:
-      - image: node:latest
-    steps:
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: npm install
-      - run:
-          name: Build Package
-          command: npm run build
-      - run:
-          name: Test Package
-          command: npm run test
-
   Publish_To_NPM:
     docker:
       - image: node:latest
@@ -69,22 +54,13 @@ workflows:
   version: 2
   Registry_Publish:
     jobs:
-      - Test_Package:
-          name: Build & Test Package
-          filters:
-            branches:
-              only: main
       - Publish_To_NPM:
           name: Publish to NPM Registry
-          requires:
-            - Build & Test Package
           filters:
             branches:
               only: main
       - Publish_To_Github:
           name: Publish to Github Registry
-          requires:
-            - Build & Test Package
           filters:
             branches:
               only: main


### PR DESCRIPTION
This pull request includes changes to the `.circleci/config.yml` file to streamline the CI/CD pipeline by removing the `Test_Package` job and its dependencies.

CI/CD pipeline simplification:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L4-L18): Removed the `Test_Package` job, which included steps for installing dependencies, building the package, and running tests.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L72-L87): Updated the `Registry_Publish` workflow to remove dependencies on the `Build & Test Package` job for the `Publish_To_NPM` and `Publish_To_Github` jobs.…he publishing process